### PR TITLE
Reduced spacing between the menu and content

### DIFF
--- a/public/scripts/panel.js
+++ b/public/scripts/panel.js
@@ -19,16 +19,13 @@ $(document).ready(function(){
 
 
     $('header').click(function(){
-        var $infoPanel = $('.info-panel');
-        if($infoPanel.hasClass('open')){
-            $infoPanel.removeClass('open');
-        }
+        closeNav();
     });
 });
 
 function closeNav() {
     $('.info-panel').removeClass('open');
-    $('.option-item').removeClass('active');
+    $('.option-item.active').removeClass('active');
 
     $('header').removeClass('open');
 }

--- a/public/styles/grid.css
+++ b/public/styles/grid.css
@@ -23,7 +23,7 @@
   }
   header {
       font-size: 3.5em;
-      letter-spacing: 0.1em;
+      letter-spacing: -4px;
       opacity: 1;
 
       -webkit-transition: opacity .5s;
@@ -43,11 +43,19 @@
       right: -55%;
   }
   nav {
-      margin: 20px ;
+      margin: 20px;
   }
+
+  .info-panel.open nav {
+      display: flex;
+      flex-wrap: wrap;
+      flex-flow: column;
+      align-items: flex-start;
+  }
+
   .option-item{
       padding: 3px;
-      margin-right: 10px
+      margin: 10px 0 0;
   }
 
   form{
@@ -100,6 +108,11 @@
     }
     p{
         padding:  20px 40px;
+    }
+
+    /* Extra padding aligns the forms with the body content */
+    form#contributeForm, #followForm {
+        padding-top: 10px;
     }
 }
 

--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -22,6 +22,8 @@ header{
     -ms-transition: opacity .5s;
     -o-transition: opacity .5s;
     transition: opacity .5s;
+
+    cursor: default;
 }
 
 header.open {
@@ -49,14 +51,8 @@ p{
   
     vertical-align: top;
     display: inline-block;
+    cursor: default;
 }
-
-@media (min-width: 375px){
-    .info-panel.open .closebtn{
-        display: block;
-    }
-}
-
 
 .closebtn {
     right: 0;
@@ -82,4 +78,8 @@ p{
 
 .right{
     float: right;
+}
+
+.info-panel.open .closebtn {
+    display: block;
 }

--- a/public/styles/typography.css
+++ b/public/styles/typography.css
@@ -72,6 +72,7 @@ p.contribute{
     font-size: 22px;
     line-height: 27px;
     letter-spacing: .05px;
+    margin-top : 0;
 }
 
 p.content{


### PR DESCRIPTION
Reduced spacing between the menu and content
Fixed letter spacing for title on mobile
Mobile content menu is now in a column, also adding a bit of padding to space them out.
Aligned forms with content body.
Removed text select cursor from the header title and p tags

Close button wasn't shown on devices < 370

Fixed bug : Clicking the header (title) to close the content pop-up now returns the text opacity to 1